### PR TITLE
Fix docker configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 node_modules
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,13 @@ RUN apk --update --no-cache add \
     libressl-dev \
     gmp-dev \
     procps-dev \
-    pkgconfig \
-    build-base \
-    boost-dev \
-    libxslt-dev \
     rsync
 
 WORKDIR /app
 COPY . .
 
 # See: https://github.com/npm/npm/issues/17346
+# and https://stackoverflow.com/a/52767310
 RUN npm config set unsafe-perm true && npm install
 RUN npx webpack-cli --config ./webpack/webpack.docker.config.js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,5 @@ ENV DOCKER true
 
 EXPOSE 8545
 
+# Further flags can be passed when starting the container (see README.md)
 ENTRYPOINT ["node", "cli.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,26 +17,29 @@ RUN apk --update --no-cache add \
     libxslt-dev \
     rsync
 
-COPY package.json /app/package.json
-COPY package-lock.json /app/package-lock.json
 WORKDIR /app
-RUN npm install
-
 COPY . .
+
+# See: https://github.com/npm/npm/issues/17346
+RUN npm config set unsafe-perm true && npm install
 RUN npx webpack-cli --config ./webpack/webpack.docker.config.js
 
-FROM mhart/alpine-node:10 as runtime
+## TODO: Uncomment and fix the lines below to have a more efficient
+## multi-stage build (to shrink the image size)
+#FROM mhart/alpine-node:10 as runtime
+#
+#WORKDIR /app
+#
+#COPY --from=builder "/app/node_modules/scrypt/build/Release" "./node_modules/scrypt/build/Release/"
+#COPY --from=builder "/app/node_modules/sha3/build/Release" "./node_modules/sha3/build/Release/"
+#COPY --from=builder "/app/node_modules/ganache-core/node_modules/websocket/build/Release" "./node_modules/ganache-core/node_modules/websocket/build/Release/"
+#COPY --from=builder "/app/build/ganache-core.docker.cli.js" "./ganache-core.docker.cli.js"
+#COPY --from=builder "/app/build/ganache-core.docker.cli.js.map" "./ganache-core.docker.cli.js.map"
 
-WORKDIR /app
-
-COPY --from=builder "/app/node_modules/scrypt/build/Release" "./node_modules/scrypt/build/Release/"
-COPY --from=builder "/app/node_modules/sha3/build/Release" "./node_modules/sha3/build/Release/"
-COPY --from=builder "/app/node_modules/ganache-core/node_modules/websocket/build/Release" "./node_modules/ganache-core/node_modules/websocket/build/Release/"
-COPY --from=builder "/app/build/ganache-core.docker.cli.js" "./ganache-core.docker.cli.js"
-COPY --from=builder "/app/build/ganache-core.docker.cli.js.map" "./ganache-core.docker.cli.js.map"
-
+# Set the docker environment to listen on 0.0.0.0
+# https://github.com/clearmatics/ganache-cli/blob/v6.10.1-clearmatics/args.js#L15
 ENV DOCKER true
 
 EXPOSE 8545
 
-ENTRYPOINT ["node", "/app/ganache-core.docker.cli.js"]
+ENTRYPOINT ["node", "cli.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,27 @@
 FROM mhart/alpine-node:10 as builder
 
-RUN apk add --no-cache make gcc g++ python git bash
+RUN apk --update --no-cache add \
+    make \
+    gcc \
+    g++ \
+    python \
+    git \
+    bash \
+    cmake \
+    libressl-dev \
+    gmp-dev \
+    procps-dev \
+    pkgconfig \
+    build-base \
+    boost-dev \
+    libxslt-dev \
+    rsync
+
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
 WORKDIR /app
 RUN npm install
+
 COPY . .
 RUN npx webpack-cli --config ./webpack/webpack.docker.config.js
 

--- a/README.md
+++ b/README.md
@@ -308,20 +308,5 @@ docker build -t clearmatics/ganache-cli-rnd .
 docker run -p 8545:8545 clearmatics/ganache-cli-rnd
 ```
 
-## Contributing to Ganache CLI
-
-The Ganache CLI repository contains the cli logic and Docker config/build only. It utilizes [ganache-core](https://github.com/trufflesuite/ganache-core), the core logic powering [Ganache](https://github.com/trufflesuite/ganache), internally.
-
-You can contribute to the core code at [ganache-core](https://github.com/trufflesuite/ganache-core).
-
-To contribue to ganache-cli, run:
-
-```Bash
-git clone https://github.com/trufflesuite/ganache-cli.git && cd ganache-cli
-npm install
-```
-
-You'll need Python 2.7 installed, and on Windows, you'll likely need to install [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools) from an Administrator PowerShell Prompt via `npm install --global windows-build-tools`.
-
 # License
 [MIT](https://tldrlegal.com/license/mit-license)

--- a/README.md
+++ b/README.md
@@ -284,39 +284,29 @@ Special non-standard methods that aren’t included within the original RPC spec
 The Simplest way to get started with the Docker image:
 
 ```Bash
-docker run -d -p 8545:8545 trufflesuite/ganache-cli:latest
+docker run -d -p 8545:8545 clearmatics/ganache-cli-rnd:latest
 ```
 
 To pass options to ganache-cli through Docker simply add the arguments to
-the run command:
+the run command, e.g.:
 
 ```Bash
-docker run -d -p 8545:8545 trufflesuite/ganache-cli:latest -a 10 --debug
-                                                           ^^^^^^^^^^^^^
+docker run -d -p 8545:8545 clearmatics/ganache-cli-rnd:latest --hardfork istanbul --gasLimit 0x3FFFFFFFFFFFF --gasPrice 1 --defaultBalanceEther 9000000000
 ```
 
 The Docker container adds an environment variable `DOCKER=true`; when this variable is set to `true` (case insensitive), `ganache-cli` use a default hostname IP of `0.0.0.0` instead of the normal default `127.0.0.1`. You can still specify a custom hostname however:
 
 ```Bash
-docker run -d -p 8545:8545 trufflesuite/ganache-cli:latest -h XXX.XXX.XXX.XXX
-                                                           ^^^^^^^^^^^^^^^^^^
+docker run -d -p 8545:8545 clearmatics/ganache-cli-rnd:latest -h XXX.XXX.XXX.XXX
+                                                              ^^^^^^^^^^^^^^^^^^
 ```
 
 To build and run the Docker container from source:
 
 ```Bash
-git clone https://github.com/trufflesuite/ganache-cli.git && cd ganache-cli
+docker build -t clearmatics/ganache-cli-rnd .
+docker run -p 8545:8545 clearmatics/ganache-cli-rnd
 ```
-then:
-```Bash
-docker build -t trufflesuite/ganache-cli .
-docker run -p 8545:8545 trufflesuite/ganache-cli
-```
-or
-```Bash
-npm run docker
-```
-
 
 ## Contributing to Ganache CLI
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "start": "node cli.js",
     "build": "webpack-cli --config ./webpack/webpack.node.config.js",
     "prepare": "npm run build",
-    "docker": "docker build -t trufflesuite/ganache-cli . && docker run -p 8545:8545 trufflesuite/ganache-cli",
     "otp": "node ./scripts/generate-otp.js",
     "releaseNotes": "npx semantic-release --dry-run"
   },


### PR DESCRIPTION
Adding missing dependencies to build the project in a docker image.

while `npm install` works, the `webpack` command `npx webpack-cli --config ./webpack/webpack.docker.config.js` fails with the following message:
```
[...]
ERROR in ./node_modules/ganache-core/lib/blockchain_double.js
Module not found: Error: Can't resolve 'ethereumjs-vm' in '/app/node_modules/ganache-core/lib'
 @ ./node_modules/ganache-core/lib/blockchain_double.js 6:9-33
 @ ./node_modules/ganache-core/lib/statemanager.js
 @ ./node_modules/ganache-core/lib/subproviders/geth_api_double.js
 @ ./node_modules/ganache-core/lib/provider.js
 @ ./node_modules/ganache-core/public-exports.js
 @ ./lib.js
 @ ./cli.js
 @ multi ./cli.js
The command '/bin/sh -c npx webpack-cli --config ./webpack/webpack.docker.config.js' returned a non-zero code: 2
```

After looking into the "tree" of "node_modules" I realized that the `dist` folder was missing in: `ganache-cli > node_modules > ganache_core > node_modules > ethereumjs-vm`, which explains the error above. I am not sure why the `dist` folder is missing -  this needs to be figured out for the docker image to be usable.