### PR TITLE
CI for docker build using GitHub Container Registry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
+.github
 node_modules
 build

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .github
 node_modules
 build
+README.md

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: "Docker build by tag vX.Y.Z-clearmatics"
+name: "Docker build vX.Y.Z-clearmatics"
 
 on:
   push:
@@ -24,6 +24,10 @@ jobs:
         id: git_vars
         run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
 
+      - name: "Get vars from git"
+        id: git_vars
+        run: echo ::set-output name=COMMIT_HASH::$(git rev-parse --short HEAD)
+
       - name: "Configure Docker"
         run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
@@ -36,10 +40,24 @@ jobs:
       - name: "Buildx build"
         run: |
           docker buildx build \
-            --tag ghcr.io/$GITHUB_REPOSITORY:${{ steps.git_vars.outputs.TAG }} \
+            --tag ghcr.io/$GITHUB_REPOSITORY:git-${{ steps.git_vars.outputs.COMMIT_HASH }} \
             --tag ghcr.io/$GITHUB_REPOSITORY:latest \
             --cache-from=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:cache \
             --cache-to=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:cache \
             --platform linux/amd64 \
             --output "type=image,push=true" \
             --file ./Dockerfile ./
+
+      - name: "Run ganache service"
+        run: docker run -d -p 8545:8545 ghcr.io/$GITHUB_REPOSITORY:git-${{ steps.git_vars.outputs.COMMIT_HASH }}
+
+      - name: "Test RPC"
+        run: ./tests/rpc.sh http://127.0.0.1:8545
+
+      - name: "Tag and push latest image to registry"
+        run: |
+          docker tag ghcr.io/$GITHUB_REPOSITORY:git-${{ steps.git_vars.outputs.COMMIT_HASH }} ghcr.io/$GITHUB_REPOSITORY:${{ steps.git_vars.outputs.TAG }}
+          docker tag ghcr.io/$GITHUB_REPOSITORY:git-${{ steps.git_vars.outputs.COMMIT_HASH }} ghcr.io/$GITHUB_REPOSITORY:latest
+          docker push ghcr.io/$GITHUB_REPOSITORY:${{ steps.git_vars.outputs.TAG }}
+          docker push ghcr.io/$GITHUB_REPOSITORY:latest
+

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,47 @@
+name: "Docker build"
+
+on:
+  push:
+    branches:
+      - clearmatics-docker
+
+env:
+  REPO_OWNER: "clearmatics"
+
+jobs:
+  docker-build:
+    name: "Docker build and push"
+    runs-on: ubuntu-20.04
+    timeout-minutes: 15
+
+    strategy:
+      matrix:
+        app: ['rnd']
+      max-parallel: 1
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+
+      - name: "Configure Docker"
+        run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+
+      - name: "Get vars from git"
+        id: git_vars
+        run: echo ::set-output name=COMMIT_HASH::$(git rev-parse --short HEAD)
+
+      - name: "Set up Buildx"
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: "Buildx build"
+        run: |
+          docker buildx build \
+            --tag ghcr.io/$REPO_OWNER/ganache-cli:${{ matrix.app }}-git-${{ steps.git_vars.outputs.COMMIT_HASH }} \
+            --cache-from=type=registry,ref=ghcr.io/$REPO_OWNER/ganache-cli:${{ matrix.app }}-cache \
+            --cache-to=type=registry,ref=ghcr.io/$REPO_OWNER/ganache-cli:${{ matrix.app }}-cache \
+            --platform linux/amd64 \
+            --output "type=image,push=false" \
+            --file ./Dockerfile ./

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,9 +1,9 @@
-name: "Docker build"
+name: "Docker build by tag vX.Y.Z-clearmatics"
 
 on:
   push:
-    branches:
-      - clearmatics-docker
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+-clearmatics # Triggered by git tags like: v0.2.12-clearmatics
 
 jobs:
   docker-build:
@@ -20,12 +20,12 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v2
 
-      - name: "Configure Docker"
-        run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-
       - name: "Get vars from git"
         id: git_vars
-        run: echo ::set-output name=COMMIT_HASH::$(git rev-parse --short HEAD)
+        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+
+      - name: "Configure Docker"
+        run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
       - name: "Set up Buildx"
         id: buildx
@@ -36,10 +36,10 @@ jobs:
       - name: "Buildx build"
         run: |
           docker buildx build \
-            --tag ghcr.io/$GITHUB_REPOSITORY:${{ matrix.app }}-git-${{ steps.git_vars.outputs.COMMIT_HASH }} \
-            --tag ghcr.io/$GITHUB_REPOSITORY:${{ matrix.app }}-latest \
-            --cache-from=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:${{ matrix.app }}-cache \
-            --cache-to=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:${{ matrix.app }}-cache \
+            --tag ghcr.io/$GITHUB_REPOSITORY:${{ steps.git_vars.outputs.COMMIT_TAG }} \
+            --tag ghcr.io/$GITHUB_REPOSITORY:latest \
+            --cache-from=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:cache \
+            --cache-to=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:cache \
             --platform linux/amd64 \
             --output "type=image,push=true" \
             --file ./Dockerfile ./

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,11 +22,9 @@ jobs:
 
       - name: "Get vars from git"
         id: git_vars
-        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
-
-      - name: "Get vars from git"
-        id: git_vars
-        run: echo ::set-output name=COMMIT_HASH::$(git rev-parse --short HEAD)
+        run: |
+          echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+          echo ::set-output name=COMMIT_HASH::$(git rev-parse --short HEAD)
 
       - name: "Configure Docker"
         run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: "Buildx build"
         run: |
           docker buildx build \
-            --tag ghcr.io/$GITHUB_REPOSITORY:${{ steps.git_vars.outputs.COMMIT_TAG }} \
+            --tag ghcr.io/$GITHUB_REPOSITORY:${{ steps.git_vars.outputs.TAG }} \
             --tag ghcr.io/$GITHUB_REPOSITORY:latest \
             --cache-from=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:cache \
             --cache-to=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:cache \

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,11 +11,6 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 20
 
-    strategy:
-      matrix:
-        app: ['rnd']
-      max-parallel: 1
-
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,14 +5,11 @@ on:
     branches:
       - clearmatics-docker
 
-env:
-  REPO_OWNER: "clearmatics"
-
 jobs:
   docker-build:
     name: "Docker build and push"
     runs-on: ubuntu-20.04
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     strategy:
       matrix:
@@ -39,9 +36,10 @@ jobs:
       - name: "Buildx build"
         run: |
           docker buildx build \
-            --tag ghcr.io/$REPO_OWNER/ganache-cli:${{ matrix.app }}-git-${{ steps.git_vars.outputs.COMMIT_HASH }} \
-            --cache-from=type=registry,ref=ghcr.io/$REPO_OWNER/ganache-cli:${{ matrix.app }}-cache \
-            --cache-to=type=registry,ref=ghcr.io/$REPO_OWNER/ganache-cli:${{ matrix.app }}-cache \
+            --tag ghcr.io/$GITHUB_REPOSITORY:${{ matrix.app }}-git-${{ steps.git_vars.outputs.COMMIT_HASH }} \
+            --tag ghcr.io/$GITHUB_REPOSITORY:${{ matrix.app }}-latest \
+            --cache-from=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:${{ matrix.app }}-cache \
+            --cache-to=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:${{ matrix.app }}-cache \
             --platform linux/amd64 \
-            --output "type=image,push=false" \
+            --output "type=image,push=true" \
             --file ./Dockerfile ./

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,18 +35,17 @@ jobs:
         with:
           version: latest
 
-      - name: "Buildx build"
+      - name: "Build and push image git-SHA"
         run: |
           docker buildx build \
             --tag ghcr.io/$GITHUB_REPOSITORY:git-${{ steps.git_vars.outputs.COMMIT_HASH }} \
-            --tag ghcr.io/$GITHUB_REPOSITORY:latest \
             --cache-from=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:cache \
             --cache-to=type=registry,ref=ghcr.io/$GITHUB_REPOSITORY:cache \
             --platform linux/amd64 \
             --output "type=image,push=true" \
             --file ./Dockerfile ./
 
-      - name: "Run ganache service"
+      - name: "Run service git-SHA for tests"
         run: docker run -d -p 8545:8545 ghcr.io/$GITHUB_REPOSITORY:git-${{ steps.git_vars.outputs.COMMIT_HASH }}
 
       - name: "Test RPC"
@@ -58,4 +57,3 @@ jobs:
           docker tag ghcr.io/$GITHUB_REPOSITORY:git-${{ steps.git_vars.outputs.COMMIT_HASH }} ghcr.io/$GITHUB_REPOSITORY:latest
           docker push ghcr.io/$GITHUB_REPOSITORY:${{ steps.git_vars.outputs.TAG }}
           docker push ghcr.io/$GITHUB_REPOSITORY:latest
-

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ TODO
 .tern-port
 .vscode
 build
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM mhart/alpine-node:10 as builder
 
+LABEL org.opencontainers.image.source https://github.com/clearmatics/ganache-cli
+
 RUN apk --update --no-cache add \
     make \
     gcc \

--- a/README.md
+++ b/README.md
@@ -284,29 +284,31 @@ Special non-standard methods that aren’t included within the original RPC spec
 The Simplest way to get started with the Docker image:
 
 ```Bash
-docker run -d -p 8545:8545 clearmatics/ganache-cli-rnd:latest
+docker run -d -p 8545:8545 ghcr.io/clearmatics/ganache-cli:latest
 ```
 
 To pass options to ganache-cli through Docker simply add the arguments to
 the run command, e.g.:
 
 ```Bash
-docker run -d -p 8545:8545 clearmatics/ganache-cli-rnd:latest --hardfork istanbul --gasLimit 0x3FFFFFFFFFFFF --gasPrice 1 --defaultBalanceEther 9000000000
+docker run -d -p 8545:8545 ghcr.io/clearmatics/ganache-cli:latest --hardfork istanbul --gasLimit 0x3FFFFFFFFFFFF --gasPrice 1 --defaultBalanceEther 9000000000
 ```
 
 The Docker container adds an environment variable `DOCKER=true`; when this variable is set to `true` (case insensitive), `ganache-cli` use a default hostname IP of `0.0.0.0` instead of the normal default `127.0.0.1`. You can still specify a custom hostname however:
 
 ```Bash
-docker run -d -p 8545:8545 clearmatics/ganache-cli-rnd:latest -h XXX.XXX.XXX.XXX
+docker run -d -p 8545:8545 ghcr.io/clearmatics/ganache-cli:latest -h XXX.XXX.XXX.XXX
                                                               ^^^^^^^^^^^^^^^^^^
 ```
 
 To build and run the Docker container from source:
 
 ```Bash
-docker build -t clearmatics/ganache-cli-rnd .
-docker run -p 8545:8545 clearmatics/ganache-cli-rnd
+docker build -t ghcr.io/clearmatics/ganache-cli .
+docker run -p 8545:8545 ghcr.io/clearmatics/ganache-cli
 ```
+
+To trigger docker autobuild by GitHub Actions push release tag like "vX.Y.Z-clearmatics"
 
 # License
 [MIT](https://tldrlegal.com/license/mit-license)

--- a/tests/rpc.sh
+++ b/tests/rpc.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+RPC_URI=${1:-"http://127.0.0.1:8545"}
+
+get_last_block_number(){
+    HEIGHT=$(set -e; curl -s -X POST -H "Content-Type: application/json" \
+        -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+        ${RPC_URI} |jq -re .result)
+    echo $HEIGHT
+}
+
+until [ "$(get_last_block_number)" == "0x0" ] ; do
+  echo "Attempt to get eth_blockNumber from "$RPC_URI
+  sleep 1
+done
+
+echo SUCCESS


### PR DESCRIPTION
To trigger autobuild push git tag `vX.Y.Z-clearmatics`

* It will build using Buildx image for `linux/amd64` using remote cache `cache` with tag `git-SHA`
* run container from `git-SHA` image
* Run simple RPC test
* If test passed - tag docker image as `vX.Y.Z-clearmatics`, `latest` and push to registry